### PR TITLE
Fixed event relay setup race

### DIFF
--- a/roger/doc.go
+++ b/roger/doc.go
@@ -1,5 +1,5 @@
 /*
 Reduce messaging boilerplate with higher-level abstractions that build on top
 of the amqp package.
- */
+*/
 package roger


### PR DESCRIPTION
The event relay methods (such as NotifyPublish) were returning before the initial setup was complete: e.g, connecting them to the underlying channel for the first time. This meant that calling routines would move on and send requests which triggered events that the channel was not yet hooked up to.

This PR adds a sync mechanism Notify methods invoke to wait on the initial connection before returning.