### PR TITLE
Feature/connection middleware

### DIFF
--- a/amqp/amqpmiddleware/handlerDefs.go
+++ b/amqp/amqpmiddleware/handlerDefs.go
@@ -19,13 +19,22 @@ const TransportTypeChannel = "CHANNEL"
 
 // HOOK DEFINITIONS
 
-// HandlerReconnect: signature for handlers triggered when a channel is being
+// HandlerChannelReconnect: signature for handlers triggered when a channel is being
 // re-established.
 //
 // Attempt is the attempt number, including all previous failures and successes.
-type HandlerReconnect = func(
+type HandlerConnectionReconnect = func(
 	ctx context.Context,
-	transportType TransportType,
+	attempt uint64,
+	logger zerolog.Logger,
+) (*streadway.Connection, error)
+
+// HandlerChannelReconnect: signature for handlers triggered when a channel is being
+// re-established.
+//
+// Attempt is the attempt number, including all previous failures and successes.
+type HandlerChannelReconnect = func(
+	ctx context.Context,
 	attempt uint64,
 	logger zerolog.Logger,
 ) (*streadway.Channel, error)
@@ -102,6 +111,22 @@ type HandlerNack func(args ArgsNack) error
 // HandlerReject: signature for handlers invoked when amqp.Channel.Reject() is called.
 type HandlerReject func(args ArgsReject) error
 
+// HandlerNotifyClose: signature for handlers invoked when the NotifyClose method
+// is called on an amqp.Connection or amqp.Channel.
+type HandlerNotifyClose func(args ArgsNotifyClose) chan *streadway.Error
+
+// HandlerNotifyDial: signature for handlers invoked when the NotifyDial method
+// is called on an amqp.Connection or amqp.Channel.
+type HandlerNotifyDial func(args ArgsNotifyDial) error
+
+// HandlerNotifyDisconnect: signature for handlers invoked when the NotifyDisconnect
+// method is called on an amqp.Connection or amqp.Channel.
+type HandlerNotifyDisconnect func(args ArgsNotifyDisconnect) error
+
+// HandlerClose: signature for handlers invoked when the Close method is called on an
+// amqp.Connection or amqp.Channel.
+type HandlerClose func(args ArgsClose) error
+
 // HandlerNotifyConfirm: signature for handlers invoked when
 // amqp.Channel.NotifyConfirm() is called.
 type HandlerNotifyConfirm func(args ArgsNotifyConfirm) (chan uint64, chan uint64)
@@ -128,31 +153,49 @@ type HandlerNotifyFlow func(args ArgsNotifyFlow) chan bool
 // amqp.Channel.NotifyPublish() is called.
 type HandlerNotifyPublish func(args ArgsNotifyPublish) chan datamodels.Confirmation
 
+// EVENT HANDLERS #####################################
+// ####################################################
+
+// HandlerNotifyDialEvents: signature for handlers invoked when an event from a
+// NotifyDial() of an amqp.Connection or amqp.Channel is being processed before
+// being sent to the caller.
+type HandlerNotifyDialEvents func(event EventNotifyDial)
+
+// HandlerNotifyDisconnectEvents: signature for handlers invoked when an event from a
+// NotifyDisconnect() of an amqp.Connection or amqp.Channel is being processed before
+// being sent to the caller.
+type HandlerNotifyDisconnectEvents func(event EventNotifyDisconnect)
+
+// HandlerNotifyCloseEvents: signature for handlers invoked when an event from a
+// NotifyClose() of an amqp.Connection or amqp.Channel is being processed before
+// being sent to the caller.
+type HandlerNotifyCloseEvents func(event EventNotifyClose)
+
 // HandlerNotifyPublishEvents: signature for handlers invoked when an event from an
-// amqp.Channel.NotifyPublish() is being processed before beings sent to the caller.
+// amqp.Channel.NotifyPublish() is being processed before being sent to the caller.
 type HandlerNotifyPublishEvents func(event EventNotifyPublish)
 
 // HandlerConsumeEvents: signature for handlers invoked when an event from an
-// amqp.Channel.Consume() is being processed before beings sent to the caller.
+// amqp.Channel.Consume() is being processed before being sent to the caller.
 type HandlerConsumeEvents func(event EventConsume)
 
 // HandlerNotifyConfirmEvents: signature for handlers invoked when an event from an
-// amqp.Channel.NotifyConfirm() is being processed before beings sent to the caller.
+// amqp.Channel.NotifyConfirm() is being processed before being sent to the caller.
 type HandlerNotifyConfirmEvents func(event EventNotifyConfirm)
 
 // HandlerNotifyConfirmOrOrphanedEvents: signature for handlers invoked when an event
-// from ab amqp.Channel.NotifyConfirmOrOrphaned() is being processed before beings sent
+// from ab amqp.Channel.NotifyConfirmOrOrphaned() is being processed before being sent
 // to the caller.
 type HandlerNotifyConfirmOrOrphanedEvents func(event EventNotifyConfirmOrOrphaned)
 
 // HandlerNotifyReturnEvents: signature for handlers invoked when an event from an
-// amqp.Channel.NotifyReturn() is being processed before beings sent to the caller.
+// amqp.Channel.NotifyReturn() is being processed before being sent to the caller.
 type HandlerNotifyReturnEvents func(event EventNotifyReturn)
 
 // HandlerNotifyCancelEvents: signature for handlers invoked when an event from an
-// amqp.Channel.NotifyReturn() is being processed before beings sent to the caller.
+// amqp.Channel.NotifyReturn() is being processed before being sent to the caller.
 type HandlerNotifyCancelEvents func(event EventNotifyCancel)
 
 // HandlerNotifyFlowEvents: signature for handlers invoked when an event from an
-// amqp.Channel.NotifyFlow() is being processed before beings sent to the caller.
+// amqp.Channel.NotifyFlow() is being processed before being sent to the caller.
 type HandlerNotifyFlowEvents func(event EventNotifyFlow)

--- a/amqp/amqpmiddleware/methodArgs.go
+++ b/amqp/amqpmiddleware/methodArgs.go
@@ -159,6 +159,32 @@ type ArgsReject struct {
 	Requeue bool
 }
 
+// ArgsNotifyClose stores args for the NotifyClose method on amqp.Connection and
+// amqp.Channel.
+type ArgsNotifyClose struct {
+	TransportType TransportType
+	Receiver      chan *streadway.Error
+}
+
+// ArgsNotifyDial stores args for the NotifyDial method on amqp.Connection and
+// amqp.Channel.
+type ArgsNotifyDial struct {
+	TransportType TransportType
+	Receiver      chan error
+}
+
+// ArgsNotifyDisconnect stores args for the NotifyDisconnect method on amqp.Connection
+// and amqp.Channel.
+type ArgsNotifyDisconnect struct {
+	TransportType TransportType
+	Receiver      chan error
+}
+
+// ArgsClose stores args for the Close method on amqp.Connection and amqp.Channel.
+type ArgsClose struct {
+	TransportType TransportType
+}
+
 // ArgsNotifyPublish stores args to amqp.Channel.NotifyPublish() for middleware to
 // inspect.
 type ArgsNotifyPublish struct {
@@ -201,7 +227,28 @@ type ArgsNotifyFlow struct {
 //
 // The below middlewares handle events from methods like NotifyPublish and Consume.
 
-// EventNotifyPublish passes event information from a  to amqp.Channel.NotifyPublish()
+// EventNotifyDial passes event information from a NotifyDial event on an
+// amqp.Connection or amqp.Channel.
+type EventNotifyDial struct {
+	TransportType TransportType
+	Err           error
+}
+
+// EventNotifyDisconnect passes event information from a NotifyDisconnect event on an
+// amqp.Connection or amqp.Channel.
+type EventNotifyDisconnect struct {
+	TransportType TransportType
+	Err           error
+}
+
+// EventNotifyClose passes event information from a NotifyClose event on an
+// amqp.Connection or amqp.Channel.
+type EventNotifyClose struct {
+	TransportType TransportType
+	Err           *streadway.Error
+}
+
+// EventNotifyPublish passes event information from an amqp.Channel.NotifyPublish()
 // event for middleware to inspect / modify before the event is passed to the caller.
 type EventNotifyPublish struct {
 	Confirmation datamodels.Confirmation

--- a/amqp/amqpmiddleware/middlewareDefs.go
+++ b/amqp/amqpmiddleware/middlewareDefs.go
@@ -2,9 +2,15 @@ package amqpmiddleware
 
 // Middleware definitions for channel methods.
 
-// Reconnect defines signature for middleware called on underlying channel reconnection
-// event.
-type Reconnect = func(next HandlerReconnect) HandlerReconnect
+// ConnectionReconnect defines signature for middleware called on underlying channel
+// reconnection event.
+type ConnectionReconnect = func(
+	next HandlerConnectionReconnect,
+) HandlerConnectionReconnect
+
+// ChannelReconnect defines signature for middleware called on underlying channel
+// reconnection event.
+type ChannelReconnect = func(next HandlerChannelReconnect) HandlerChannelReconnect
 
 // QueueDeclare defines signature for middleware invoked on *amqp.Channel.QueueDeclare()
 // and *amqp.Channel.QueueDeclarePassive() call.
@@ -73,6 +79,22 @@ type Nack func(next HandlerNack) HandlerNack
 // Reject defines signature for middleware invoked on *amqp.Channel.Reject() call.
 type Reject func(next HandlerReject) HandlerReject
 
+// NotifyClose defines signature for middleware invoked on the NotifyClose method of
+// an amqp.Connection or amqp.Channel.
+type NotifyClose func(next HandlerNotifyClose) HandlerNotifyClose
+
+// NotifyDial defines signature for middleware invoked on the NotifyDial method of
+// an amqp.Connection or amqp.Channel.
+type NotifyDial func(next HandlerNotifyDial) HandlerNotifyDial
+
+// NotifyDisconnect defines signature for middleware invoked on the NotifyDisconnect
+// method of an amqp.Connection or amqp.Channel.
+type NotifyDisconnect func(next HandlerNotifyDisconnect) HandlerNotifyDisconnect
+
+// Close defines signature for middleware invoked on the Close method of an
+// amqp.Connection or amqp.Channel.
+type Close func(next HandlerClose) HandlerClose
+
 // NotifyPublish defines signature for middleware invoked on
 // *amqp.Channel.NotifyPublish() call.
 type NotifyPublish func(next HandlerNotifyPublish) HandlerNotifyPublish
@@ -98,6 +120,28 @@ type NotifyCancel func(next HandlerNotifyCancel) HandlerNotifyCancel
 // NotifyFlow defines signature for middleware invoked on *amqp.Channel.NotifyFlow()
 // call.
 type NotifyFlow func(next HandlerNotifyFlow) HandlerNotifyFlow
+
+// EVENT MIDDLEWARE #####################################
+// ######################################################
+
+// NotifyDialEvents defines signature for middleware invoked on event processed
+// during relay of NotifyConnect() events on either an amqp.Connection or amqp.Channel.
+type NotifyDialEvents func(
+	next HandlerNotifyDialEvents,
+) HandlerNotifyDialEvents
+
+// NotifyDisconnectEvents defines signature for middleware invoked on event processed
+// during relay of NotifyDisconnect() events on either an amqp.Connection or
+// amqp.Channel.
+type NotifyDisconnectEvents func(
+	next HandlerNotifyDisconnectEvents,
+) HandlerNotifyDisconnectEvents
+
+// NotifyCloseEvents defines signature for middleware invoked on event processed
+// during relay of NotifyClose() events on either an amqp.Connection or amqp.Channel.
+type NotifyCloseEvents func(
+	next HandlerNotifyCloseEvents,
+) HandlerNotifyCloseEvents
 
 // NotifyPublishEvents defines signature for middleware invoked on event processed
 // during relay of *amqp.Channel.NotifyPublish() events.

--- a/amqp/channel.go
+++ b/amqp/channel.go
@@ -35,6 +35,10 @@ type transportChannel struct {
 	logger zerolog.Logger
 }
 
+func (transport *transportChannel) TypeName() amqpmiddleware.TransportType {
+	return amqpmiddleware.TransportTypeChannel
+}
+
 // cleanup implements transport and releases a WorkGroup that allows event relays
 // to fully close
 func (transport *transportChannel) cleanup() error {
@@ -62,10 +66,8 @@ func (transport *transportChannel) tryReconnect(
 		logger.Debug().Msg("getting new channel")
 	}
 
-	// Invoke all our reconnection middleware and reconnect the channel.
-	channel, err := transport.handlers.reconnect(
-		ctx, amqpmiddleware.TransportTypeChannel, attempt, logger,
-	)
+	// Invoke all our reconnection middleware and channelReconnect the channel.
+	channel, err := transport.handlers.channelReconnect(ctx, attempt, logger)
 	if err != nil {
 		return err
 	}
@@ -793,7 +795,7 @@ identify the binding.
 ---
 
 ROGER NOTE: All relevant bindings will be removed from the list of bindings to declare
-on reconnect.
+on channelReconnect.
 */
 func (channel *Channel) ExchangeUnbind(
 	destination, key, source string, noWait bool, args Table,

--- a/amqp/channelEventRelaysSync.go
+++ b/amqp/channelEventRelaysSync.go
@@ -185,7 +185,7 @@ func (relaySync *relaySync) WaitToSetup() {
 	if !relaySync.firstSetupDone {
 		relaySync.shared.transportLock.RLock()
 	} else {
-		// Otherwise wait until the reconnect gives us the all clear
+		// Otherwise wait until the channelReconnect gives us the all clear
 		relaySync.shared.runSetup.Wait()
 	}
 }

--- a/amqp/channelHandlersBase.go
+++ b/amqp/channelHandlersBase.go
@@ -8,22 +8,21 @@ import (
 	streadway "github.com/streadway/amqp"
 )
 
-// middlewareBaseBuilder builds the base method handlers for a given robust
+// channelHandlerBaseBuilder builds the base method handlers for a given robust
 // connection + channel
-type middlewareBaseBuilder struct {
+type channelHandlerBaseBuilder struct {
 	connection     *Connection
 	channel        *Channel
 	underlyingChan *streadway.Channel
 }
 
-// createBaseHandlerReconnect returns the base handler invoked on a Channel
+// createBaseHandlerChannelReconnect returns the base handler invoked on a Channel
 // reconnection.
-func (builder *middlewareBaseBuilder) createBaseHandlerReconnect() (
-	handler amqpmiddleware.HandlerReconnect,
+func (builder *channelHandlerBaseBuilder) createBaseHandlerChannelReconnect() (
+	handler amqpmiddleware.HandlerChannelReconnect,
 ) {
 	handler = func(
 		ctx context.Context,
-		transportType amqpmiddleware.TransportType,
 		attempt uint64,
 		logger zerolog.Logger,
 	) (*streadway.Channel, error) {
@@ -40,7 +39,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerReconnect() (
 
 // createBaseHandlerQueueDeclare returns the base handler for Channel.QueueDeclare
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerQueueDeclare() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerQueueDeclare() (
 	handler amqpmiddleware.HandlerQueueDeclare,
 ) {
 	handler = func(args amqpmiddleware.ArgsQueueDeclare) (Queue, error) {
@@ -60,7 +59,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerQueueDeclare() (
 // createBaseHandlerQueueDeclarePassive returns the base handler for
 // Channel.QueueDeclarePassive that invokes the method of the underlying
 // streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerQueueDeclarePassive() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerQueueDeclarePassive() (
 	handler amqpmiddleware.HandlerQueueDeclare,
 ) {
 	handler = func(args amqpmiddleware.ArgsQueueDeclare) (Queue, error) {
@@ -79,7 +78,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerQueueDeclarePassive() (
 
 // createBaseHandlerQueueInspect returns the base handler for Channel.QueueInspect that
 // invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerQueueInspect() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerQueueInspect() (
 	handler amqpmiddleware.HandlerQueueInspect,
 ) {
 	handler = func(args amqpmiddleware.ArgsQueueInspect) (Queue, error) {
@@ -91,7 +90,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerQueueInspect() (
 
 // createBaseHandlerQueueDelete returns the base handler for Channel.QueueDelete
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerQueueDelete() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerQueueDelete() (
 	handler amqpmiddleware.HandlerQueueDelete,
 ) {
 	handler = func(args amqpmiddleware.ArgsQueueDelete) (int, error) {
@@ -108,7 +107,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerQueueDelete() (
 
 // createBaseHandlerQueueBind returns the base handler for Channel.QueueBind
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerQueueBind() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerQueueBind() (
 	handler amqpmiddleware.HandlerQueueBind,
 ) {
 	handler = func(args amqpmiddleware.ArgsQueueBind) error {
@@ -126,7 +125,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerQueueBind() (
 
 // createBaseHandlerQueueUnbind returns the base handler for Channel.QueueUnbind
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerQueueUnbind() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerQueueUnbind() (
 	handler amqpmiddleware.HandlerQueueUnbind,
 ) {
 	handler = func(args amqpmiddleware.ArgsQueueUnbind) error {
@@ -143,7 +142,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerQueueUnbind() (
 
 // createBaseHandlerQueueUnbind returns the base handler for Channel.QueuePurge
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerQueuePurge() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerQueuePurge() (
 	handler amqpmiddleware.HandlerQueuePurge,
 ) {
 	handler = func(args amqpmiddleware.ArgsQueuePurge) (int, error) {
@@ -158,7 +157,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerQueuePurge() (
 
 // createBaseHandlerExchangeDeclare returns the base handler for Channel.ExchangeDeclare
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerExchangeDeclare() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerExchangeDeclare() (
 	handler amqpmiddleware.HandlerExchangeDeclare,
 ) {
 	handler = func(args amqpmiddleware.ArgsExchangeDeclare) error {
@@ -179,7 +178,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerExchangeDeclare() (
 // createBaseHandlerExchangeDeclarePassive returns the base handler for
 // Channel.ExchangeDeclarePassive that invokes the method of the underlying
 // streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerExchangeDeclarePassive() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerExchangeDeclarePassive() (
 	handler amqpmiddleware.HandlerExchangeDeclare,
 ) {
 	handler = func(args amqpmiddleware.ArgsExchangeDeclare) error {
@@ -199,7 +198,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerExchangeDeclarePassive() 
 
 // createBaseHandlerExchangeDelete returns the base handler for Channel.ExchangeDelete
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerExchangeDelete() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerExchangeDelete() (
 	handler amqpmiddleware.HandlerExchangeDelete,
 ) {
 	handler = func(args amqpmiddleware.ArgsExchangeDelete) error {
@@ -215,7 +214,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerExchangeDelete() (
 
 // createBaseHandlerExchangeBind returns the base handler for Channel.ExchangeBind
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerExchangeBind() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerExchangeBind() (
 	handler amqpmiddleware.HandlerExchangeBind,
 ) {
 	handler = func(args amqpmiddleware.ArgsExchangeBind) error {
@@ -233,7 +232,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerExchangeBind() (
 
 // createBaseHandlerExchangeUnbind returns the base handler for Channel.ExchangeUnbind
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerExchangeUnbind() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerExchangeUnbind() (
 	handler amqpmiddleware.HandlerExchangeUnbind,
 ) {
 	handler = func(args amqpmiddleware.ArgsExchangeUnbind) error {
@@ -251,7 +250,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerExchangeUnbind() (
 
 // createBaseHandlerQoS returns the base handler for Channel.Qos that invokes the method
 // of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerQoS() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerQoS() (
 	handler amqpmiddleware.HandlerQoS,
 ) {
 	handler = func(args amqpmiddleware.ArgsQoS) error {
@@ -267,7 +266,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerQoS() (
 
 // createBaseHandlerFlow returns the base handler for Channel.Flow that invokes the
 // method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerFlow() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerFlow() (
 	handler amqpmiddleware.HandlerFlow,
 ) {
 	handler = func(args amqpmiddleware.ArgsFlow) error {
@@ -279,7 +278,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerFlow() (
 
 // createBaseHandlerConfirm returns the base handler for Channel.Confirm that invokes
 // the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerConfirm() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerConfirm() (
 	handler amqpmiddleware.HandlerConfirm,
 ) {
 	handler = func(args amqpmiddleware.ArgsConfirms) error {
@@ -293,7 +292,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerConfirm() (
 
 // createBaseHandlerPublish returns the base handler for Channel.Publish that invokes
 // the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerPublish() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerPublish() (
 	handler amqpmiddleware.HandlerPublish,
 ) {
 	handler = func(args amqpmiddleware.ArgsPublish) error {
@@ -311,7 +310,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerPublish() (
 
 // createBaseHandlerGet returns the base handler for Channel.Get that invokes the method
 // of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerGet() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerGet() (
 	handler amqpmiddleware.HandlerGet,
 ) {
 	handler = func(args amqpmiddleware.ArgsGet) (msg Delivery, ok bool, err error) {
@@ -326,7 +325,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerGet() (
 
 // createBaseHandlerConsume returns the base handler for Channel.Get that invokes the
 // method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerConsume() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerConsume() (
 	handler amqpmiddleware.HandlerConsume,
 ) {
 	handler = func(
@@ -370,7 +369,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerConsume() (
 
 // createBaseHandlerAck returns the base handler for Channel.Ack that invokes the method
 // of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerAck() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerAck() (
 	handler amqpmiddleware.HandlerAck,
 ) {
 	handler = func(args amqpmiddleware.ArgsAck) error {
@@ -382,7 +381,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerAck() (
 
 // createBaseHandlerNack returns the base handler for Channel.Nack that invokes the
 // method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerNack() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerNack() (
 	handler amqpmiddleware.HandlerNack,
 ) {
 	handler = func(args amqpmiddleware.ArgsNack) error {
@@ -394,7 +393,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerNack() (
 
 // createBaseHandlerReject returns the base handler for Channel.Reject that invokes the
 // method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerReject() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerReject() (
 	handler amqpmiddleware.HandlerReject,
 ) {
 	handler = func(args amqpmiddleware.ArgsReject) error {
@@ -406,7 +405,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerReject() (
 
 // createBaseHandlerNotifyPublish returns the base handler for Channel.NotifyPublish
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerNotifyPublish() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerNotifyPublish() (
 	handler amqpmiddleware.HandlerNotifyPublish,
 ) {
 	channel := builder.channel
@@ -433,7 +432,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerNotifyPublish() (
 
 // createBaseHandlerNotifyConfirm returns the base handler for Channel.NotifyConfirm
 // that invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerNotifyConfirm() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerNotifyConfirm() (
 	handler amqpmiddleware.HandlerNotifyConfirm,
 ) {
 	channel := builder.channel
@@ -469,7 +468,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerNotifyConfirm() (
 
 // runNotifyConfirm relay the NotifyConfirm events to the caller by calling
 // NotifyPublish.
-func (builder *middlewareBaseBuilder) runNotifyConfirm(
+func (builder *channelHandlerBaseBuilder) runNotifyConfirm(
 	args amqpmiddleware.ArgsNotifyConfirm,
 	eventHandler amqpmiddleware.HandlerNotifyConfirmEvents,
 ) {
@@ -493,7 +492,7 @@ func (builder *middlewareBaseBuilder) runNotifyConfirm(
 
 // createBaseHandlerNotifyConfirmOrOrphaned returns the base handler for
 // Channel.NotifyConfirmOrOrphaned.
-func (builder *middlewareBaseBuilder) createBaseHandlerNotifyConfirmOrOrphaned() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerNotifyConfirmOrOrphaned() (
 	handler amqpmiddleware.HandlerNotifyConfirmOrOrphaned,
 ) {
 	channel := builder.channel
@@ -521,7 +520,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerNotifyConfirmOrOrphaned()
 
 // createEventHandlerNotifyConfirmOrOrphaned creates an event handler for event on
 // Channel.NotifyConfirmOrOrphaned using user-supplied middleware.
-func (builder *middlewareBaseBuilder) createEventHandlerNotifyConfirmOrOrphaned(
+func (builder *channelHandlerBaseBuilder) createEventHandlerNotifyConfirmOrOrphaned(
 	args amqpmiddleware.ArgsNotifyConfirmOrOrphaned,
 ) amqpmiddleware.HandlerNotifyConfirmOrOrphanedEvents {
 	logger := builder.channel.logger.With().
@@ -557,7 +556,7 @@ func (builder *middlewareBaseBuilder) createEventHandlerNotifyConfirmOrOrphaned(
 }
 
 // invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerNotifyReturn() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerNotifyReturn() (
 	handler amqpmiddleware.HandlerNotifyReturn,
 ) {
 	channel := builder.channel
@@ -580,7 +579,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerNotifyReturn() (
 
 // createBaseHandlerNotifyCancel returns the base handler for Channel.NotifyCancel that
 // invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerNotifyCancel() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerNotifyCancel() (
 	handler amqpmiddleware.HandlerNotifyCancel,
 ) {
 	channel := builder.channel
@@ -604,7 +603,7 @@ func (builder *middlewareBaseBuilder) createBaseHandlerNotifyCancel() (
 
 // createBaseHandlerNotifyFlow returns the base handler for Channel.NotifyFlow that
 // invokes the method of the underlying streadway/amqp.Channel.
-func (builder *middlewareBaseBuilder) createBaseHandlerNotifyFlow() (
+func (builder *channelHandlerBaseBuilder) createBaseHandlerNotifyFlow() (
 	handler amqpmiddleware.HandlerNotifyFlow,
 ) {
 	channel := builder.channel

--- a/amqp/defaultmiddlewares/confirms.go
+++ b/amqp/defaultmiddlewares/confirms.go
@@ -23,15 +23,14 @@ func (middleware *ConfirmsMiddleware) ConfirmsOn() bool {
 // Reconnect puts the new, underlying connection into confirmation mode if Confirm()
 // has been called.
 func (middleware *ConfirmsMiddleware) Reconnect(
-	next amqpmiddleware.HandlerReconnect,
-) (handler amqpmiddleware.HandlerReconnect) {
+	next amqpmiddleware.HandlerChannelReconnect,
+) (handler amqpmiddleware.HandlerChannelReconnect) {
 	return func(
 		ctx context.Context,
-		transportType amqpmiddleware.TransportType,
 		attempt uint64,
 		logger zerolog.Logger,
 	) (*streadway.Channel, error) {
-		channel, err := next(ctx, transportType, attempt, logger)
+		channel, err := next(ctx, attempt, logger)
 		// If there was an error or QoS() has not been called, return results.
 		if err != nil || !middleware.confirmsOn {
 			return channel, err

--- a/amqp/defaultmiddlewares/deliveryTags.go
+++ b/amqp/defaultmiddlewares/deliveryTags.go
@@ -27,17 +27,16 @@ type DeliveryTagsMiddleware struct {
 // Reconnect establishes our current delivery tag offset based on how many deliveries
 // have been consumed across all of our connections so far.
 func (middleware *DeliveryTagsMiddleware) Reconnect(
-	next amqpmiddleware.HandlerReconnect,
-) (handler amqpmiddleware.HandlerReconnect) {
+	next amqpmiddleware.HandlerChannelReconnect,
+) (handler amqpmiddleware.HandlerChannelReconnect) {
 	handler = func(
 		ctx context.Context,
-		transportType amqpmiddleware.TransportType,
 		attempt uint64,
 		logger zerolog.Logger,
 	) (*streadway.Channel, error) {
 		middleware.tagConsumeOffset = *middleware.tagConsumeCount
 
-		channel, err := next(ctx, transportType, attempt, logger)
+		channel, err := next(ctx, attempt, logger)
 		if err != nil {
 			return channel, err
 

--- a/amqp/defaultmiddlewares/flow.go
+++ b/amqp/defaultmiddlewares/flow.go
@@ -26,15 +26,14 @@ func (middleware *FlowMiddleware) Active() bool {
 // Reconnect sets amqp.Channel.Flow(flow=false) on the underlying channel as soon as a
 // reconnection occurs if the user has paused the flow on the channel.
 func (middleware *FlowMiddleware) Reconnect(
-	next amqpmiddleware.HandlerReconnect,
-) (handler amqpmiddleware.HandlerReconnect) {
+	next amqpmiddleware.HandlerChannelReconnect,
+) (handler amqpmiddleware.HandlerChannelReconnect) {
 	return func(
 		ctx context.Context,
-		transportType amqpmiddleware.TransportType,
 		attempt uint64,
 		logger zerolog.Logger,
 	) (*streadway.Channel, error) {
-		channel, err := next(ctx, transportType, attempt, logger)
+		channel, err := next(ctx, attempt, logger)
 		// New channels start out active, so if flow is active we can keep chugging.
 		if err != nil || middleware.active {
 			return channel, err

--- a/amqp/defaultmiddlewares/publishTag.go
+++ b/amqp/defaultmiddlewares/publishTag.go
@@ -73,11 +73,10 @@ func (middleware *PublishTagsMiddleware) reconnectSendOrphans() {
 // offset based on the current publish count, and send orphan events to all
 // amqp.Channel.NotifyPublish() listeners.
 func (middleware *PublishTagsMiddleware) Reconnect(
-	next amqpmiddleware.HandlerReconnect,
-) (handler amqpmiddleware.HandlerReconnect) {
+	next amqpmiddleware.HandlerChannelReconnect,
+) (handler amqpmiddleware.HandlerChannelReconnect) {
 	handler = func(
 		ctx context.Context,
-		transportType amqpmiddleware.TransportType,
 		attempt uint64,
 		logger zerolog.Logger,
 	) (*streadway.Channel, error) {
@@ -92,7 +91,7 @@ func (middleware *PublishTagsMiddleware) Reconnect(
 		}()
 
 		// While those are cooking , we can move forward with getting the channel.
-		channel, err := next(ctx, transportType, attempt, logger)
+		channel, err := next(ctx, attempt, logger)
 		// Once the channel returns, wait for all our orphan notifications to be sent
 		// out.
 		sendDone.Wait()

--- a/amqp/defaultmiddlewares/qos.go
+++ b/amqp/defaultmiddlewares/qos.go
@@ -32,15 +32,14 @@ func (middleware *QoSMiddleware) IsSet() bool {
 // Reconnect is called whenever the underlying channel is reconnected. This middleware
 // re-applies any QoS calls to the channel.
 func (middleware *QoSMiddleware) Reconnect(
-	next amqpmiddleware.HandlerReconnect,
-) (handler amqpmiddleware.HandlerReconnect) {
+	next amqpmiddleware.HandlerChannelReconnect,
+) (handler amqpmiddleware.HandlerChannelReconnect) {
 	return func(
 		ctx context.Context,
-		transportType amqpmiddleware.TransportType,
 		attempt uint64,
 		logger zerolog.Logger,
 	) (*streadway.Channel, error) {
-		channel, err := next(ctx, transportType, attempt, logger)
+		channel, err := next(ctx, attempt, logger)
 		// If there was an error or QoS() has not been called, return results.
 		if err != nil || !middleware.isSet {
 			return channel, err

--- a/amqp/defaultmiddlewares/routeDeclaration.go
+++ b/amqp/defaultmiddlewares/routeDeclaration.go
@@ -443,12 +443,11 @@ func (middle *RouteDeclarationMiddleware) reconnectBindExchanges(
 // reconnection event.
 func (middle *RouteDeclarationMiddleware) reconnectHandler(
 	ctx context.Context,
-	transportType amqpmiddleware.TransportType,
 	attempt uint64,
 	logger zerolog.Logger,
-	next amqpmiddleware.HandlerReconnect,
+	next amqpmiddleware.HandlerChannelReconnect,
 ) (*streadway.Channel, error) {
-	channel, err := next(ctx, transportType, attempt, logger)
+	channel, err := next(ctx, attempt, logger)
 	// If there was an error, pass it up the chain.
 	if err != nil {
 		return channel, err
@@ -481,15 +480,14 @@ func (middle *RouteDeclarationMiddleware) reconnectHandler(
 // our queue and exchange topology is re-configured to present a seamless experience
 // to the caller.
 func (middle *RouteDeclarationMiddleware) Reconnect(
-	next amqpmiddleware.HandlerReconnect,
-) (handler amqpmiddleware.HandlerReconnect) {
+	next amqpmiddleware.HandlerChannelReconnect,
+) (handler amqpmiddleware.HandlerChannelReconnect) {
 	handler = func(
 		ctx context.Context,
-		transportType amqpmiddleware.TransportType,
 		attempt uint64,
 		logger zerolog.Logger,
 	) (*streadway.Channel, error) {
-		return middle.reconnectHandler(ctx, transportType, attempt, logger, next)
+		return middle.reconnectHandler(ctx, attempt, logger, next)
 	}
 
 	return handler

--- a/amqp/examples_test.go
+++ b/amqp/examples_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-// Channel reconnect examples.
+// Channel channelReconnect examples.
 func ExampleChannel_reconnect() {
 	// Get a new connection to our test broker.
 	//
@@ -32,7 +32,7 @@ func ExampleChannel_reconnect() {
 
 	// We can use the test method to return an testing object with some additional
 	// methods. ForceReconnect force-closes the underlying transport, causing the
-	// robust connection to reconnect.
+	// robust connection to channelReconnect.
 	//
 	// We'll use a dummy *testing.T object here. These methods are designed for tests
 	// only and should not be used in production code.
@@ -141,7 +141,7 @@ func ExampleChannel_Consume_deliveryTags() {
 
 		// Range over the consume channel
 		for delivery := range consume {
-			// Force-reconnect the channel after each delivery.
+			// Force-channelReconnect the channel after each delivery.
 			consumeChannel.Test(new(testing.T)).ForceReconnect(context.Background())
 
 			// Tick down the consumeComplete WaitGroup
@@ -544,7 +544,7 @@ func ExampleChannel_Test() {
 	// test's *testing.T value. Here, we will just pass a dummy one.
 	testHarness := channel.Test(new(testing.T))
 
-	// We can use the test harness to force the channel to reconnect. If a reconnection
+	// We can use the test harness to force the channel to channelReconnect. If a reconnection
 	// does not occur before the passed context expires, the test will be failed.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/amqp/transportManagerHandlers.go
+++ b/amqp/transportManagerHandlers.go
@@ -1,0 +1,108 @@
+package amqp
+
+import (
+	"github.com/peake100/rogerRabbit-go/amqp/amqpmiddleware"
+)
+
+// transportManagerHandlers holds the method handlers and event middleware for
+// transportManager methods.
+type transportManagerHandlers struct {
+	// METHOD HANDLERS
+	// ---------------
+
+	// notifyClose is the handler invoked when transportManager.NotifyClose is called.
+	notifyClose amqpmiddleware.HandlerNotifyClose
+
+	// notifyDial is the handler invoked when transportManager.NotifyDial is called.
+	notifyDial amqpmiddleware.HandlerNotifyDial
+
+	// notifyDisconnect is the handler invoked when transportManager.NotifyDisconnect
+	// is called.
+	notifyDisconnect amqpmiddleware.HandlerNotifyDisconnect
+
+	// transportClose is the handler invoked when transportManager.Close is called.
+	transportClose amqpmiddleware.HandlerClose
+
+	// EVENT Middleware
+	// ----------------
+	notifyDialEvents       []amqpmiddleware.NotifyDialEvents
+	notifyDisconnectEvents []amqpmiddleware.NotifyDisconnectEvents
+	notifyCloseEvents      []amqpmiddleware.NotifyCloseEvents
+}
+
+// AddNotifyClose adds a new middleware to be invoked on a Connection or Channel
+// NotifyClose method call.
+func (handlers *transportManagerHandlers) AddNotifyClose(
+	middleware amqpmiddleware.NotifyClose,
+) {
+	handlers.notifyClose = middleware(handlers.notifyClose)
+}
+
+// AddNotifyDial adds a new middleware to be invoked on a Connection or Channel
+// NotifyClose method call.
+func (handlers *transportManagerHandlers) AddNotifyDial(
+	middleware amqpmiddleware.NotifyDial,
+) {
+	handlers.notifyDial = middleware(handlers.notifyDial)
+}
+
+// AddNotifyDisconnect adds a new middleware to be invoked on a Connection or Channel
+// NotifyDisconnect method call.
+func (handlers *transportManagerHandlers) AddNotifyDisconnect(
+	middleware amqpmiddleware.NotifyDisconnect,
+) {
+	handlers.notifyDisconnect = middleware(handlers.notifyDisconnect)
+}
+
+// AddClose adds a new middleware to be invoked on a Connection or Channel Close method
+// call.
+func (handlers *transportManagerHandlers) AddClose(
+	middleware amqpmiddleware.Close,
+) {
+	handlers.transportClose = middleware(handlers.transportClose)
+}
+
+// AddNotifyDialEvents adds a new middleware to be invoked on each Connection or Channel
+// NotifyDial event.
+func (handlers *transportManagerHandlers) AddNotifyDialEvents(
+	middleware amqpmiddleware.NotifyDialEvents,
+) {
+	handlers.notifyDialEvents = append(handlers.notifyDialEvents, middleware)
+}
+
+// AddNotifyDisconnectEvents adds a new middleware to be invoked on each Connection or
+// Channel NotifyDisconnect event.
+func (handlers *transportManagerHandlers) AddNotifyDisconnectEvents(
+	middleware amqpmiddleware.NotifyDisconnectEvents,
+) {
+	handlers.notifyDisconnectEvents = append(
+		handlers.notifyDisconnectEvents, middleware,
+	)
+}
+
+// AddNotifyCloseEvents adds a new middleware to be invoked on each Connection or
+// Channel NotifyClose event.
+func (handlers *transportManagerHandlers) AddNotifyCloseEvents(
+	middleware amqpmiddleware.NotifyCloseEvents,
+) {
+	handlers.notifyCloseEvents = append(handlers.notifyCloseEvents, middleware)
+}
+
+// newTransportManagerHandlers creates the base method handlers for a transportManager
+// and returns a transportManagerHandlers with them.
+func newTransportManagerHandlers(manager *transportManager) transportManagerHandlers {
+	builder := transportHandlersBaseBuilder{
+		manager: manager,
+	}
+
+	return transportManagerHandlers{
+		notifyClose:      builder.createBaseNotifyClose(),
+		notifyDial:       builder.createBaseNotifyDial(),
+		notifyDisconnect: builder.createBaseNotifyDisconnect(),
+		transportClose:   builder.createBaseClose(),
+
+		notifyDialEvents:       nil,
+		notifyDisconnectEvents: nil,
+		notifyCloseEvents:      nil,
+	}
+}

--- a/amqp/transportManagerHandlersBase.go
+++ b/amqp/transportManagerHandlersBase.go
@@ -1,0 +1,161 @@
+package amqp
+
+import (
+	"github.com/peake100/rogerRabbit-go/amqp/amqpmiddleware"
+	streadway "github.com/streadway/amqp"
+)
+
+// transportHandlersBaseBuilder builds the base handlers for transportManager methods.
+type transportHandlersBaseBuilder struct {
+	manager *transportManager
+}
+
+// createBaseNotifyClose creates the base handler for transportManager.NotifyClose.
+func (builder transportHandlersBaseBuilder) createBaseNotifyClose() amqpmiddleware.HandlerNotifyClose {
+	manager := builder.manager
+	return func(args amqpmiddleware.ArgsNotifyClose) chan *streadway.Error {
+		manager.notificationSubscriberLock.Lock()
+		defer manager.notificationSubscriberLock.Unlock()
+
+		// If the context of the transport manager has been cancelled, close the
+		// receiver and exit.
+		if manager.ctx.Err() != nil {
+			close(args.Receiver)
+			return args.Receiver
+		}
+
+		manager.notificationSubscriberClose = append(
+			manager.notificationSubscriberClose, args.Receiver,
+		)
+
+		var eventHandler amqpmiddleware.HandlerNotifyCloseEvents = func(
+			event amqpmiddleware.EventNotifyClose,
+		) {
+			// We send the error then close the channel. This handler will only be
+			// called once on the final transport close.
+			args.Receiver <- event.Err
+			close(args.Receiver)
+		}
+
+		for _, middleware := range manager.handlers.notifyCloseEvents {
+			eventHandler = middleware(eventHandler)
+		}
+
+		manager.notifyCloseEventHandlers = append(
+			manager.notifyCloseEventHandlers, eventHandler,
+		)
+
+		return args.Receiver
+	}
+}
+
+// createBaseNotifyDial creates the base handler for transportManager.NotifyDial.
+func (builder transportHandlersBaseBuilder) createBaseNotifyDial() amqpmiddleware.HandlerNotifyDial {
+	manager := builder.manager
+	return func(args amqpmiddleware.ArgsNotifyDial) error {
+		manager.notificationSubscriberLock.Lock()
+		defer manager.notificationSubscriberLock.Unlock()
+
+		// If the context of the transport manager has been cancelled, close the
+		// receiver and exit.
+		if manager.ctx.Err() != nil {
+			close(args.Receiver)
+			return streadway.ErrClosed
+		}
+
+		manager.notificationSubscribersDial = append(
+			manager.notificationSubscribersDial, args.Receiver,
+		)
+
+		// Add the event handler to the list of event handlers.
+		var eventHandler amqpmiddleware.HandlerNotifyDialEvents = func(
+			event amqpmiddleware.EventNotifyDial,
+		) {
+			args.Receiver <- event.Err
+		}
+
+		for _, thisMiddleware := range manager.handlers.notifyDialEvents {
+			eventHandler = thisMiddleware(eventHandler)
+		}
+
+		manager.notifyDialEventHandlers = append(
+			manager.notifyDialEventHandlers, eventHandler,
+		)
+
+		return nil
+	}
+}
+
+// createBaseNotifyDisconnect creates the base handler for
+// transportManager.NotifyDisconnect.
+func (builder transportHandlersBaseBuilder) createBaseNotifyDisconnect() amqpmiddleware.HandlerNotifyDisconnect {
+	manager := builder.manager
+	return func(args amqpmiddleware.ArgsNotifyDisconnect) error {
+		manager.notificationSubscriberLock.Lock()
+		defer manager.notificationSubscriberLock.Unlock()
+
+		// If the context of the transport manager has been cancelled, close the
+		// receiver and exit.
+		if manager.ctx.Err() != nil {
+			close(args.Receiver)
+			return streadway.ErrClosed
+		}
+
+		manager.notificationSubscriberDisconnect = append(
+			manager.notificationSubscriberDisconnect, args.Receiver,
+		)
+
+		// Set up the event handler for this receiver.
+		var eventHandler amqpmiddleware.HandlerNotifyDisconnectEvents = func(
+			event amqpmiddleware.EventNotifyDisconnect,
+		) {
+			args.Receiver <- event.Err
+		}
+
+		for _, middleware := range builder.manager.handlers.notifyDisconnectEvents {
+			eventHandler = middleware(eventHandler)
+		}
+
+		manager.notifyDisconnectEventHandlers = append(
+			manager.notifyDisconnectEventHandlers, eventHandler,
+		)
+
+		return nil
+	}
+}
+
+// createBaseClose creates the base handler for transportManager.Close.
+func (builder transportHandlersBaseBuilder) createBaseClose() amqpmiddleware.HandlerClose {
+	manager := builder.manager
+	return func(args amqpmiddleware.ArgsClose) error {
+		// If the context has already been cancelled, we can exit.
+		if manager.ctx.Err() != nil {
+			return streadway.ErrClosed
+		}
+
+		manager.cancelCtxCloseTransport()
+
+		// Close all disconnect and connect subscribers, then clear them. We don't
+		// need to grab the lock for this since the cancelled context will keep any new
+		// subscribers from being added.
+		for _, subscriber := range manager.notificationSubscribersDial {
+			close(subscriber)
+		}
+		// We clear these to avoid sending on a nil channel.
+		manager.notificationSubscribersDial = nil
+		manager.notifyDialEventHandlers = nil
+
+		for _, subscriber := range manager.notificationSubscriberDisconnect {
+			close(subscriber)
+		}
+		// We clear these to avoid sending on a nil channel.
+		manager.notificationSubscriberDisconnect = nil
+		manager.notifyDisconnectEventHandlers = nil
+
+		// Send closure notifications to all subscribers.
+		manager.sendCloseNotifications(nil)
+
+		// Execute any cleanup on behalf of the transport implementation.
+		return manager.transport.cleanup()
+	}
+}

--- a/amqp/transportManagerHandlersBase.go
+++ b/amqp/transportManagerHandlersBase.go
@@ -11,7 +11,9 @@ type transportHandlersBaseBuilder struct {
 }
 
 // createBaseNotifyClose creates the base handler for transportManager.NotifyClose.
-func (builder transportHandlersBaseBuilder) createBaseNotifyClose() amqpmiddleware.HandlerNotifyClose {
+func (
+	builder transportHandlersBaseBuilder,
+) createBaseNotifyClose() amqpmiddleware.HandlerNotifyClose {
 	manager := builder.manager
 	return func(args amqpmiddleware.ArgsNotifyClose) chan *streadway.Error {
 		manager.notificationSubscriberLock.Lock()
@@ -50,7 +52,9 @@ func (builder transportHandlersBaseBuilder) createBaseNotifyClose() amqpmiddlewa
 }
 
 // createBaseNotifyDial creates the base handler for transportManager.NotifyDial.
-func (builder transportHandlersBaseBuilder) createBaseNotifyDial() amqpmiddleware.HandlerNotifyDial {
+func (
+	builder transportHandlersBaseBuilder,
+) createBaseNotifyDial() amqpmiddleware.HandlerNotifyDial {
 	manager := builder.manager
 	return func(args amqpmiddleware.ArgsNotifyDial) error {
 		manager.notificationSubscriberLock.Lock()
@@ -88,7 +92,9 @@ func (builder transportHandlersBaseBuilder) createBaseNotifyDial() amqpmiddlewar
 
 // createBaseNotifyDisconnect creates the base handler for
 // transportManager.NotifyDisconnect.
-func (builder transportHandlersBaseBuilder) createBaseNotifyDisconnect() amqpmiddleware.HandlerNotifyDisconnect {
+func (
+	builder transportHandlersBaseBuilder,
+) createBaseNotifyDisconnect() amqpmiddleware.HandlerNotifyDisconnect {
 	manager := builder.manager
 	return func(args amqpmiddleware.ArgsNotifyDisconnect) error {
 		manager.notificationSubscriberLock.Lock()
@@ -125,7 +131,9 @@ func (builder transportHandlersBaseBuilder) createBaseNotifyDisconnect() amqpmid
 }
 
 // createBaseClose creates the base handler for transportManager.Close.
-func (builder transportHandlersBaseBuilder) createBaseClose() amqpmiddleware.HandlerClose {
+func (
+	builder transportHandlersBaseBuilder,
+) createBaseClose() amqpmiddleware.HandlerClose {
 	manager := builder.manager
 	return func(args amqpmiddleware.ArgsClose) error {
 		// If the context has already been cancelled, we can exit.

--- a/amqp/transportManagerReconnect.go
+++ b/amqp/transportManagerReconnect.go
@@ -19,7 +19,7 @@ func (manager *transportManager) reconnectRedialOnce(ctx context.Context) error 
 		manager.logger.Debug().Err(err).Msg("error re-dialing connection")
 	}
 	// Send a notification to all listeners subscribed to dial events.
-	manager.sendConnectNotifications(err)
+	manager.sendDialNotifications(err)
 	if err != nil {
 		manager.logger.
 			Error().


### PR DESCRIPTION
Closes #16

Connections (and transports in general) now have a full set of middleware and handlers.

However the way this is exposed to the User leads a lot to be desired. We should probably move towards a Config-Driven way of handling middleware configuration, so middleware is set up before the channel / connection is created rather than on it once it is running.