### PR TITLE
Fixes Data Races in Roger Package

### DIFF
--- a/amqp/transportManager.go
+++ b/amqp/transportManager.go
@@ -265,7 +265,7 @@ func isRepeatErr(err error) bool {
 
 // retryOperationOnClosedSingle attempts a Connection or Channel channel method a single
 // time.
-func (manager transportManager) retryOperationOnClosedSingle(
+func (manager *transportManager) retryOperationOnClosedSingle(
 	transportCtx context.Context,
 	opCtx context.Context,
 	operation func(ctx context.Context) error,
@@ -305,7 +305,7 @@ func (manager transportManager) retryOperationOnClosedSingle(
 // returned or ctx expires. This is a helper method for implementing methods like
 // Channel.QueueBind, in which we want to retry the operation if our underlying
 // livesOnce mechanism has connection issues.
-func (manager transportManager) retryOperationOnClosed(
+func (manager *transportManager) retryOperationOnClosed(
 	transportCtx context.Context,
 	operation func(ctx context.Context) error,
 	retry bool,

--- a/roger/consumer_test.go
+++ b/roger/consumer_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/peake100/rogerRabbit-go/amqp/datamodels"
 	"github.com/peake100/rogerRabbit-go/amqptest"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/suite"
 	"sync"
 	"testing"
@@ -60,7 +59,7 @@ func (consumer *BasicTestConsumer) SetupChannel(
 }
 
 func (consumer *BasicTestConsumer) HandleDelivery(
-	ctx context.Context, delivery datamodels.Delivery, logger zerolog.Logger,
+	ctx context.Context, delivery datamodels.Delivery,
 ) (err error, requeue bool) {
 
 	// Check whether all messages have been received, then signal receipt.
@@ -70,11 +69,6 @@ func (consumer *BasicTestConsumer) HandleDelivery(
 	if consumer.ReceivedMessageCount == consumer.ExpectedMessageCount {
 		close(consumer.AllReceived)
 	}
-
-	logger.Info().
-		Bytes("BODY", delivery.Body).
-		Int("RECEIVED_COUNT", consumer.ReceivedMessageCount).
-		Msg("message received")
 
 	return nil, false
 }


### PR DESCRIPTION
- removed roger logger (needs to be re-implemented as middleware anyway)
- converted remaining transport manager methods to pointer-receivers. This was causing data races on re-dial