### PR TITLE
Bug/Relay Initialization Race

### DIFF
--- a/amqp/channelEventRelays.go
+++ b/amqp/channelEventRelays.go
@@ -56,7 +56,7 @@ func (channel *Channel) runEventRelay(relay eventRelay, relaySync relaySync) {
 	defer shutdownRelay(relay, relaySync)
 
 	firstLegComplete := make(chan struct{})
-	channel.eventRelaySetup(relay, relaySync, firstLegComplete)
+	channel.eventRelayInitialSetup(relay, relaySync, firstLegComplete)
 
 	// Wait for ou first leg to complete, then fall into a rhythm with the transport
 	// manager
@@ -73,7 +73,11 @@ func (channel *Channel) runEventRelay(relay eventRelay, relaySync relaySync) {
 	}
 }
 
-func (channel *Channel) eventRelaySetup(
+// eventRelayInitialSetup does the initial setup of an event relay. We need to make sure
+// that setup is complete before we return to the user, otherwise they may start taking
+// actions that SHOULD trigger events before the event listener has been registered with
+// the underlying streadway/amqp.Channel.
+func (channel *Channel) eventRelayInitialSetup(
 	relay eventRelay, relaySync relaySync, firstLegComplete chan struct{},
 ) {
 	// Signal this leg in an op so we can make sure we grab the right channel.

--- a/amqp/channelHandlersBuilder.go
+++ b/amqp/channelHandlersBuilder.go
@@ -666,7 +666,6 @@ func (builder channelHandlerBuilder) createNotifyReturn() amqpmiddleware.Handler
 
 	handler := func(ctx context.Context, args amqpmiddleware.ArgsNotifyReturn) amqpmiddleware.ResultsNotifyReturn {
 		relay := newNotifyReturnRelay(args.Returns, eventMiddlewares)
-
 		channel.eventRelaySetupAndLaunch(relay)
 		return amqpmiddleware.ResultsNotifyReturn{Returns: args.Returns}
 	}

--- a/amqp/channelHandlersBuilder.go
+++ b/amqp/channelHandlersBuilder.go
@@ -458,7 +458,7 @@ func (builder channelHandlerBuilder) createConsume() amqpmiddleware.HandlerConsu
 		relay := newConsumeRelay(callArgs, channel, eventMiddleware)
 
 		// Pass it to our relay handler.
-		channel.setupAndLaunchEventRelay(relay)
+		channel.eventRelaySetupAndLaunch(relay)
 
 		results.DeliveryChan = callArgs.callerDeliveryChan
 		// If no error, pass the channel back to the caller
@@ -537,7 +537,7 @@ func (builder channelHandlerBuilder) createNotifyPublish() amqpmiddleware.Handle
 	) amqpmiddleware.ResultsNotifyPublish {
 		relay := newNotifyPublishRelay(args.Confirm, eventMiddleware)
 
-		channel.setupAndLaunchEventRelay(relay)
+		channel.eventRelaySetupAndLaunch(relay)
 
 		return amqpmiddleware.ResultsNotifyPublish{Confirm: args.Confirm}
 	}
@@ -667,7 +667,7 @@ func (builder channelHandlerBuilder) createNotifyReturn() amqpmiddleware.Handler
 	handler := func(ctx context.Context, args amqpmiddleware.ArgsNotifyReturn) amqpmiddleware.ResultsNotifyReturn {
 		relay := newNotifyReturnRelay(args.Returns, eventMiddlewares)
 
-		channel.setupAndLaunchEventRelay(relay)
+		channel.eventRelaySetupAndLaunch(relay)
 		return amqpmiddleware.ResultsNotifyReturn{Returns: args.Returns}
 	}
 
@@ -683,7 +683,7 @@ func (builder channelHandlerBuilder) createNotifyCancel() amqpmiddleware.Handler
 	handler := func(ctx context.Context, args amqpmiddleware.ArgsNotifyCancel) amqpmiddleware.ResultsNotifyCancel {
 		relay := newNotifyCancelRelay(args.Cancellations, eventMiddlewares)
 
-		channel.setupAndLaunchEventRelay(relay)
+		channel.eventRelaySetupAndLaunch(relay)
 		return amqpmiddleware.ResultsNotifyCancel{Cancellations: args.Cancellations}
 	}
 
@@ -705,7 +705,7 @@ func (builder channelHandlerBuilder) createNotifyFlow() amqpmiddleware.HandlerNo
 		)
 
 		// Setup and launch the relay.
-		channel.setupAndLaunchEventRelay(relay)
+		channel.eventRelaySetupAndLaunch(relay)
 		return amqpmiddleware.ResultsNotifyFlow{FlowNotifications: args.FlowNotifications}
 	}
 

--- a/amqp/channel_test.go
+++ b/amqp/channel_test.go
@@ -934,8 +934,6 @@ func (suite *ChannelMethodsSuite) Test0160_NotifyConfirm() {
 
 	suite.ChannelPublish().NotifyConfirm(ackEvents, nackEvents)
 
-	confirmations := new(sync.WaitGroup)
-
 	go func() {
 		for i := 0; i < publishCount; i++ {
 			err := suite.ChannelPublish().Publish(
@@ -950,8 +948,6 @@ func (suite *ChannelMethodsSuite) Test0160_NotifyConfirm() {
 			if !suite.NoErrorf(err, "publish %v", i) {
 				suite.T().FailNow()
 			}
-			// Add 1 to the confirmation WaitGroup
-			confirmations.Add(1)
 		}
 	}()
 
@@ -983,7 +979,7 @@ func (suite *ChannelMethodsSuite) Test0160_NotifyConfirm() {
 			suite.T().FailNow()
 		}
 
-		if receivedCount >= 10 {
+		if receivedCount >= publishCount {
 			break
 		}
 	}

--- a/amqp/transportManager.go
+++ b/amqp/transportManager.go
@@ -333,7 +333,7 @@ func (manager *transportManager) retryOperationOnClosed(
 		//
 		// We'll give one immediate retry, but after that start increasing how long
 		// we need to wait before re-attempting.
-		waitDur := 5 * time.Millisecond * time.Duration(attempt - 1)
+		waitDur := 5 * time.Millisecond * time.Duration(attempt-1)
 		if waitDur > maxWait {
 			waitDur = maxWait
 		}
@@ -509,11 +509,11 @@ func (manager *transportManager) setup(
 	transport reconnects,
 	middleware transportManagerMiddleware,
 ) {
-	ctx, cancelFunc := context.WithCancel(ctx)
+	newCtx, cancelFunc := context.WithCancel(ctx)
 
 	reconnectCount := uint64(0)
 
-	manager.ctx = ctx
+	manager.ctx = newCtx
 	manager.cancelFunc = cancelFunc
 	manager.transport = transport
 	manager.transportLock = new(sync.RWMutex)

--- a/amqp/transportManager.go
+++ b/amqp/transportManager.go
@@ -299,6 +299,8 @@ func (manager *transportManager) retryOperationOnClosedSingle(
 	return err
 }
 
+// maxWait is the max amount of time a method should wait before trying again after
+// multiple failures in a row.
 const maxWait = time.Second * 5
 
 // revive:enable:context-as-argument

--- a/amqp/transportManager.go
+++ b/amqp/transportManager.go
@@ -299,7 +299,7 @@ func (manager *transportManager) retryOperationOnClosedSingle(
 	return err
 }
 
-const maxWait = time.Second * 10
+const maxWait = time.Second * 5
 
 // revive:enable:context-as-argument
 
@@ -332,7 +332,7 @@ func (manager *transportManager) retryOperationOnClosed(
 		// We'll give one immediate retry, but after that start increasing how long
 		// we need to wait before re-attempting.
 		waitDur := 5 * time.Millisecond * time.Duration(attempt - 1)
-		if waitDur > time.Second * 30 {
+		if waitDur > maxWait {
 			waitDur = maxWait
 		}
 		time.Sleep(waitDur)

--- a/amqptest/testSuite.go
+++ b/amqptest/testSuite.go
@@ -360,9 +360,10 @@ func (amqpSuite *AmqpSuite) publishMessagesSend(
 ) {
 	assert := assert.New(t)
 
+	channel := amqpSuite.ChannelPublish()
 	for i := 0; i < count; i++ {
 		msg := strconv.Itoa(i)
-		err := amqpSuite.ChannelPublish().Publish(
+		err := channel.Publish(
 			exchange,
 			key,
 			true,
@@ -397,6 +398,7 @@ func (amqpSuite *AmqpSuite) publishMessagesConfirm(
 				allConfirmed <- fmt.Errorf("message %v nacked", confirmCount)
 				return
 			}
+			confirmCount++
 		case <-returns:
 			t.Error("message returned by broker")
 			allConfirmed <- errors.New("message returned by broker")
@@ -404,7 +406,6 @@ func (amqpSuite *AmqpSuite) publishMessagesConfirm(
 		case <-ctx.Done():
 			return
 		}
-		confirmCount++
 		if confirmCount == count {
 			return
 		}


### PR DESCRIPTION
This PR fixes a logical error with event relays where initial setup and registration with the underlying channel was not guaranteed to be complete before returning the event channel to the user.

Hopefully closes #41 