### PR TITLE
Feature/consumer catch panics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	code.cloudfoundry.org/go-diodes v0.0.0-20190809170250-f77fb823c7ee
 	github.com/onsi/ginkgo v1.16.1 // indirect
 	github.com/onsi/gomega v1.11.0 // indirect
+	github.com/peake100/pears-go v0.0.3 // indirect
 	github.com/rs/zerolog v1.20.0
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.11.0 h1:+CqWgvj0OZycCaqclBD1pxKHAU+tOkHmQIWvDHq2aug=
 github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQLTUg=
+github.com/peake100/pears-go v0.0.3 h1:FzW91KrrUHx9TpYhKMHnL1+0FI+UpdMZZsTdJ+Jt8Ac=
+github.com/peake100/pears-go v0.0.3/go.mod h1:ymrIN9l+l/HfcacI7AtuAA18pEGjg/0G0YIUHIcaMjA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/roger/rconsumer/opts.go
+++ b/pkg/roger/rconsumer/opts.go
@@ -13,7 +13,7 @@ type Opts struct {
 	// The maximum number of workers that can be active at one time.
 	maxWorkers int
 
-	// The middleware we should add to each AmqpDeliveryProcessor.
+	// The middleware we should add to each DeliveryProcessor.
 	middleware Middleware
 
 	// noLoggingMiddleware is true if we should not add logging middleware.
@@ -127,19 +127,19 @@ type Middleware struct {
 }
 
 // AddSetupChannel adds a middleware.SetupChannel to be added to each
-// AmqpDeliveryProcessor.SetupChannel passed to a Consumer.
+// DeliveryProcessor.SetupChannel passed to a Consumer.
 func (config *Middleware) AddSetupChannel(processorMiddleware middleware.SetupChannel) {
 	config.setupChannel = append(config.setupChannel, processorMiddleware)
 }
 
 // AddDelivery adds a middleware.Delivery to be added to each
-// AmqpDeliveryProcessor.HandleDelivery passed to a Consumer.
+// DeliveryProcessor.HandleDelivery passed to a Consumer.
 func (config *Middleware) AddDelivery(processorMiddleware middleware.Delivery) {
 	config.delivery = append(config.delivery, processorMiddleware)
 }
 
 // AddCleanupChannel adds a middleware.CleanupChannel to be added to each
-// AmqpDeliveryProcessor.CleanupChannel passed to a Consumer.
+// DeliveryProcessor.CleanupChannel passed to a Consumer.
 func (config *Middleware) AddCleanupChannel(processorMiddleware middleware.CleanupChannel) {
 	config.cleanupChannel = append(config.cleanupChannel, processorMiddleware)
 }
@@ -150,7 +150,7 @@ func (config *Middleware) AddProvider(provider middleware.ProvidesMiddleware) er
 }
 
 // AddCleanupChannel adds a middleware.CleanupChannel to be added to each
-// AmqpDeliveryProcessor.CleanupChannel passed to a Consumer.
+// DeliveryProcessor.CleanupChannel passed to a Consumer.
 func (config *Middleware) addProviderMethods(provider middleware.ProvidesMiddleware) error {
 	// Check if this provider has already been registered.
 	if _, ok := config.providers[provider.TypeID()]; ok {

--- a/pkg/roger/rconsumer/requiredMiddleware.go
+++ b/pkg/roger/rconsumer/requiredMiddleware.go
@@ -1,0 +1,71 @@
+package rconsumer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/peake100/pears-go/pkg/pears"
+	"github.com/peake100/rogerRabbit-go/pkg/amqp"
+	"github.com/peake100/rogerRabbit-go/pkg/roger/rconsumer/middleware"
+)
+
+// DefaultRecoverDeliveryPanic is used as the innermost middleware for deliveries. It catches panics
+// and converts them to pears.PanicError errors.
+var recoverPanicMiddleware = func(next middleware.HandlerDelivery) middleware.HandlerDelivery {
+	return func(ctx context.Context, delivery amqp.Delivery) (requeue bool, err error) {
+		err = pears.CatchPanic(func() (innerErr error) {
+			requeue, innerErr = next(ctx, delivery)
+			return innerErr
+		})
+		return requeue, err
+	}
+}
+
+// mewAckNackMiddleware returns a new middleware.Delivery that handles acking or nacking
+// deliveries after the core handler processes them. We want to implement this as a
+// middleware so that other middlewares, like logging middlewares, have access to any
+// ack or nack errors.
+func mewAckNackMiddleware(autoAck bool) middleware.Delivery {
+	return func(next middleware.HandlerDelivery) middleware.HandlerDelivery {
+		return func(ctx context.Context, delivery amqp.Delivery) (requeue bool, err error) {
+			requeue, err = next(ctx, delivery)
+			// If we are auto-acking, continue.
+			if autoAck {
+				return requeue, err
+			}
+
+			err = handleAck(delivery, requeue, err)
+			return requeue, err
+		}
+	}
+}
+
+func handleAck(delivery amqp.Delivery, requeue bool, err error) error {
+	// Otherwise ack non-error returns and nack error returns.
+	if err == nil {
+		ackErr := delivery.Ack(false)
+		if ackErr != nil {
+			err = fmt.Errorf("error acking delivery: %w", err)
+		}
+	} else {
+		// Recovered panics will always result in a delivery being nacked.
+		if requeue && errors.As(err, &pears.PanicError{}) {
+			requeue = false
+		}
+		nackErr := delivery.Nack(false, requeue)
+		if nackErr != nil {
+			nackErr = fmt.Errorf("error nacking delivery: %w", err)
+			// Save both errors.
+			err = pears.BatchErrors{
+				MatchMode: pears.BatchMatchFirst,
+				Errs: []error{
+					err,
+					nackErr,
+				},
+			}
+		}
+
+	}
+
+	return err
+}


### PR DESCRIPTION
Consumer Delivery Handler panics are now caught and bubbled up as an error via [pears-go](https://github.com/peake100/pears-go)