### PR TITLE
removed QueuePurge in test processor setup

### DIFF
--- a/pkg/roger/rconsumer/consumer_test.go
+++ b/pkg/roger/rconsumer/consumer_test.go
@@ -55,14 +55,6 @@ func (consumer *BasicTestProcessor) SetupChannel(
 		return fmt.Errorf("error declaring Queue: %w", err)
 	}
 
-	_, err = amqpChannel.QueuePurge(
-		consumer.QueueName,
-		false,
-	)
-	if err != nil {
-		return fmt.Errorf("error purging Queue: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
The test delivery processor purged the queue as part of its setup. Because the setup was running in a goroutine, this could cause a race condition where test publications were being made before the queue purge was called, so the first set of publications would be purged.

The purge is not necessary. The test helper setting up the queue for us  in the first place purges the messages, so we don't need to do it in the setup handler.