### PR TITLE
Fixes deadlock and logic race for handling closed channels

### DIFF
--- a/pkg/amqp/amqpmiddleware/methodResults.go
+++ b/pkg/amqp/amqpmiddleware/methodResults.go
@@ -14,13 +14,21 @@ type ResultsNotifyClose struct {
 // ResultsConnectionReconnect are the result values from a Connection reconnection event
 // for middleware to inspect.
 type ResultsConnectionReconnect struct {
+	// Connection is the newly connected underlying connection.
 	Connection *streadway.Connection
+	// CloseNotifications is the channel that the transport manager will listen to
+	// closure events on.
+	CloseNotifications chan *streadway.Error
 }
 
 // ResultsChannelReconnect are the result values from a Channel reconnection event for
 // middleware to inspect.
 type ResultsChannelReconnect struct {
+	// Channel is the newly connected underlying channel.
 	Channel *streadway.Channel
+	// CloseNotifications is the channel that the transport manager will listen to
+	// closure events on.
+	CloseNotifications chan *streadway.Error
 }
 
 // ResultsQueueDeclare are the result values from a Channel.QueuePurge call for

--- a/pkg/amqp/channelHandlersBuilder.go
+++ b/pkg/amqp/channelHandlersBuilder.go
@@ -29,6 +29,9 @@ func (builder channelHandlerBuilder) createChannelReconnect() amqpmiddleware.Han
 		if err != nil {
 			return results, err
 		}
+		results.CloseNotifications = make(chan *streadway.Error, 1)
+		results.Channel.NotifyClose(results.CloseNotifications)
+
 		return results, nil
 	}
 

--- a/pkg/amqp/transportManagerReconnect.go
+++ b/pkg/amqp/transportManagerReconnect.go
@@ -8,69 +8,40 @@ import (
 	"time"
 )
 
-// reconnectRedialOnce attempts to reconnect the livesOnce a single time.
-func (manager *transportManager) reconnectRedialOnce(ctx context.Context, attempt int) error {
-	opCtx := context.WithValue(ctx, amqpmiddleware.MetadataKey("opAttempt"), attempt)
+// reconnect establishes a new underlying connection and sets up a listener for it's
+// closure.
+func (manager *transportManager) reconnect(ctx context.Context, retry bool) error {
+	// This may be called directly by Dial methods. It's okay NOT to use the lock here
+	// since the caller won't be handed back the Connection or Channel until the initial
+	// one is established.
+	//
+	// Once the first connection is established, reconnectListenForClose will grab
+	// the lock immediately on a disconnect.
 
-	// Make the connection.
-	err := manager.transport.tryReconnect(
-		opCtx, atomic.LoadUint64(manager.reconnectCount)+uint64(attempt),
-	)
-	// Send a notification to all listeners subscribed to dial events.
-	manager.sendDialNotifications(err)
+	// Redial the broker until we reconnectMiddleware
+	closeChan, err := manager.reconnectRedial(ctx, retry)
 	if err != nil {
-		// Otherwise, return (and possibly try again).
 		return err
 	}
 
-	// Increment our reconnection count tracker.
-	atomic.AddUint64(manager.reconnectCount, 1)
+	// Broadcast that we have made a successful reconnection to any one-time listeners.
+	manager.reconnectCond.Broadcast()
 
-	// If there was no error, break out of the loop.
+	// Launch a goroutine to reconnectMiddleware on connection closure.
+	go manager.reconnectListenForClose(closeChan)
+
 	return nil
 }
 
-// reconnectRedial tries to reconnect the livesOnce until successful or ctx is
-// cancelled.
-func (manager *transportManager) reconnectRedial(
-	ctx context.Context, retry bool,
-) error {
-	// Endlessly redial the broker
-	attempt := 0
-	for {
-		// Check to see if our context has been cancelled, and exit if so.
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		err := manager.reconnectRedialOnce(ctx, attempt)
-		// If no error OR there is an error and retry is false return.
-		if err == nil || (err != nil && !retry) {
-			return err
-		}
-
-		// We don'tb want to saturate the connection with retries if we are having
-		// a hard time reconnecting.
-		//
-		// We'll give one immediate retry, but after that start increasing how long
-		// we need to wait before re-attempting.
-		waitDur := time.Second / 2 * time.Duration(attempt-1)
-		if waitDur > maxWait {
-			waitDur = maxWait
-		}
-		time.Sleep(waitDur)
-		attempt++
-	}
-}
 
 // reconnectListenForClose listens for a close event from the underlying livesOnce, and
 // starts the reconnection process.
 func (manager *transportManager) reconnectListenForClose(closeChan <-chan *streadway.Error) {
-	// Wait for the current connection to close
-	disconnectEvent := <-closeChan
+	// Wait for a disconnection event.
+	disconnectEvent := manager.receiveDisconnectEventAndLockChannel(closeChan)
 
-	// Lock access to the connection and don'tb unlock until we have reconnected.
-	manager.transportLock.Lock()
+	// receiveDisconnectEventAndLockChannel already grabbed our transport lock for
+	// write, so we just need to release the lock when we exit.
 	defer manager.transportLock.Unlock()
 
 	// Send a disconnect event to all interested subscribers.
@@ -86,31 +57,100 @@ func (manager *transportManager) reconnectListenForClose(closeChan <-chan *strea
 	_ = manager.reconnect(manager.ctx, true)
 }
 
-// reconnect establishes a new underlying connection and sets up a listener for it's
-// closure.
-func (manager *transportManager) reconnect(ctx context.Context, retry bool) error {
-	// This may be called directly by Dial methods. It's okay NOT to use the lock here
-	// since the caller won'tb be handed back the Connection or Channel until the initial
-	// one is established.
-	//
-	// Once the first connection is established, reconnectListenForClose will grab
-	// the lock immediately on a disconnect.
+func (manager *transportManager) receiveDisconnectEventAndLockChannel(notifyClose <-chan *streadway.Error) error {
+	// Wait for the current connection to close
+	var disconnectEvent error
 
-	// Redial the broker until we reconnectMiddleware
-	err := manager.reconnectRedial(ctx, retry)
-	if err != nil {
-		return err
+	select {
+	// Get an event from the current underlying channel. Both of these paths will
+	// immediately lock the channel so we don't waste any time in blocking methods
+	// and reduce returned errors to the caller.
+	case streadwayEvent := <-notifyClose:
+		// Lock access to the connection and don't unlock until we have reconnected.
+		manager.transportLock.Lock()
+
+		// If the event is not nil, use it as our error. We need to do this because
+		// a nil *streadway.Error pointer is still a non-nil error interface value.
+		if streadwayEvent != nil {
+			disconnectEvent = streadwayEvent
+		}
+	// Or get a report from an operation that there was an error in the event that
+	// streadway fails to signal us.
+	case disconnectEvent = <-manager.opErrorEncountered:
+		// Lock access to the connection and don't unlock until we have reconnected.
+		manager.transportLock.Lock()
+
+		// Give streadway an extra 50ms to signal. We prefer to report it's error.
+		timer := time.NewTimer(50 * time.Millisecond)
+		defer timer.Stop()
+
+		select {
+		case streadwayEvent := <-notifyClose:
+			// If it does, use this as the disconnection event.
+			if streadwayEvent != nil {
+				disconnectEvent = streadwayEvent
+			}
+		case <-timer.C:
+		}
 	}
 
-	// Register a notification channelConsume for the new connection's closure.
-	closeChan := make(chan *streadway.Error, 1)
-	manager.transport.underlyingTransport().NotifyClose(closeChan)
+	return disconnectEvent
+}
 
-	// Broadcast that we have made a successful reconnection to any one-time listeners.
-	manager.reconnectCond.Broadcast()
+// reconnectRedial tries to reconnect the livesOnce until successful or ctx is
+// cancelled.
+func (manager *transportManager) reconnectRedial(ctx context.Context, retry bool) (chan *streadway.Error, error) {
+	// Endlessly redial the broker
+	attempt := 0
 
-	// Launch a goroutine to reconnectMiddleware on connection closure.
-	go manager.reconnectListenForClose(closeChan)
+	for {
+		// Check to see if our context has been cancelled, and exit if so.
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 
-	return nil
+		closeNotifications, err := manager.reconnectRedialOnce(ctx, attempt)
+		// If no error OR there is an error and retry is false return.
+		if err == nil || (err != nil && !retry) {
+			return closeNotifications, err
+		}
+
+		// We don't want to saturate the connection with retries if we are having
+		// a hard time reconnecting.
+		//
+		// We'll give one immediate retry, but after that start increasing how long
+		// we need to wait before re-attempting.
+		waitDur := time.Second / 2 * time.Duration(attempt-1)
+		if waitDur > maxWait {
+			waitDur = maxWait
+		}
+		time.Sleep(waitDur)
+		attempt++
+	}
+}
+
+// reconnectRedialOnce attempts to reconnect the livesOnce a single time.
+func (manager *transportManager) reconnectRedialOnce(ctx context.Context, attempt int) (chan *streadway.Error, error) {
+	opCtx := context.WithValue(ctx, amqpmiddleware.MetadataKey("opAttempt"), attempt)
+
+	// Replace the operation error alert. It might have another error in from the
+	// middleware of the last attempt.
+	manager.opErrorEncountered = make(chan error, 1)
+
+	// Make the connection.
+	closeNotifications, err := manager.transport.tryReconnect(
+		opCtx, atomic.LoadUint64(manager.reconnectCount)+uint64(attempt),
+	)
+	// Send a notification to all listeners subscribed to dial events.
+	manager.sendDialNotifications(err)
+	if err != nil {
+		// Otherwise, return (and possibly try again).
+		return nil, err
+	}
+
+	// Increment our reconnection count tracker.
+	atomic.AddUint64(manager.reconnectCount, 1)
+
+	// If there was no error, break out of the loop.
+	return closeNotifications, nil
 }


### PR DESCRIPTION
Closes #53.

Looking at the streadway/amqp package, it seems that no matter what, a channel passed to NotifyClose *should* signal, even if the error happened before the call to NotifyClose.

However, during tests, this does not seem to be the case.

Fixes:

- The NotifyClose event channel is now established inside the core reconnect handlers before ANY other action is taken on the streadway Channel / Connection.
- Operations now also send a signal when encountering a disconnection error that the redial routine listens for. This way, if streadway does not signal, the redial routine will still move forward with a transport replacement.